### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -36,7 +36,7 @@ jobs:
         echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:mivano/azure-cost-cli is:issue created:${{ env.last_month }} -reason:"not planned"'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
